### PR TITLE
add Broadcast flag for router advertisements

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ type RegistryCmd struct {
 	MirrorResolveRetries         int           `arg:"--mirror-resolve-retries,env:MIRROR_RESOLVE_RETRIES" default:"3" help:"Max amount of mirrors to attempt."`
 	ResolveLatestTag             bool          `arg:"--resolve-latest-tag,env:RESOLVE_LATEST_TAG" default:"true" help:"When true latest tags will be resolved to digests."`
 	DebugWebEnabled              bool          `arg:"--debug-web-enabled,env:DEBUG_WEB_ENABLED" default:"false" help:"When true enables debug web page."`
+	Broadcast                    bool          `arg:"--broadcast,env:BROADCAST" default:"false" help:"Broadcast content advertisements across the cluster."`
 	registry.PushConfig
 }
 
@@ -171,7 +172,7 @@ func registryCommand(ctx context.Context, args *RegistryCmd) (err error) {
 
 	// State tracking
 	g.Go(func() error {
-		err := state.Track(ctx, ociStore, router, args.ResolveLatestTag)
+		err := state.Track(ctx, ociStore, router, args.ResolveLatestTag, args.Broadcast)
 		if err != nil {
 			return err
 		}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spegel-org/spegel/pkg/routing"
 )
 
-func Track(ctx context.Context, ociStore oci.Store, router routing.Router, resolveLatestTag bool) error {
+func Track(ctx context.Context, ociStore oci.Store, router routing.Router, resolveLatestTag bool, brdcst bool) error {
 	log := logr.FromContextOrDiscard(ctx)
 	eventCh, err := ociStore.Subscribe(ctx)
 	if err != nil {
@@ -41,7 +41,7 @@ func Track(ctx context.Context, ociStore oci.Store, router routing.Router, resol
 				return errors.New("event channel closed")
 			}
 			log.Info("OCI event", "key", event.Key, "type", event.Type)
-			err := handle(ctx, router, event)
+			err := handle(ctx, router, event, brdcst)
 			if err != nil {
 				log.Error(err, "could not handle event")
 				continue
@@ -107,11 +107,11 @@ func tick(ctx context.Context, ociStore oci.Store, router routing.Router, resolv
 	return nil
 }
 
-func handle(ctx context.Context, router routing.Router, event oci.OCIEvent) error {
+func handle(ctx context.Context, router routing.Router, event oci.OCIEvent, brdcst bool) error {
 	if event.Type != oci.CreateEvent {
 		return nil
 	}
-	err := router.Advertise(ctx, []string{event.Key}, false)
+	err := router.Advertise(ctx, []string{event.Key}, brdcst)
 	if err != nil {
 		return err
 	}

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -80,7 +80,7 @@ func TestTrack(t *testing.T) {
 			router := routing.NewMemoryRouter(map[string][]netip.AddrPort{}, netip.MustParseAddrPort("127.0.0.1:5000"))
 			g, gCtx := errgroup.WithContext(ctx)
 			g.Go(func() error {
-				return Track(gCtx, ociStore, router, tt.resolveLatestTag)
+				return Track(gCtx, ociStore, router, tt.resolveLatestTag, false)
 			})
 			time.Sleep(100 * time.Millisecond)
 


### PR DESCRIPTION
When the flag is enabled, router advertisements will be proactively broadcast across the cluster, ensuring more complete availability of
newly-pulled content, at the cost of extra advertisement messages across the network.