### PR TITLE
Fix error when starting with push enabled

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -177,7 +177,6 @@ func (r *Registry) Handler() *httpx.ServeMux {
 	m.Handle("GET /readyz", r.readyHandler)
 	m.Handle("GET /livez", r.livenesHandler)
 	m.Handle("GET /v2/", r.registryHandler)
-	m.Handle("HEAD /v2/", r.registryHandler)
 	if r.push.Enabled {
 		m.Handle("GET /v2/{app_name}/blobs/uploads/{uuid}", r.pushHandler)
 		m.Handle("PUT /v2/", r.pushHandler)

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -73,6 +73,16 @@ func TestProbeHandlers(t *testing.T) {
 	require.Equal(t, http.StatusOK, rw.Result().StatusCode)
 }
 
+func TestHandlerWithPushEnabled(t *testing.T) {
+	t.Parallel()
+
+	reg, err := NewRegistry(nil, nil, WithPushConfig(PushConfig{Enabled: true}))
+	require.NoError(t, err)
+	require.NotPanics(t, func() {
+		_ = reg.Handler()
+	})
+}
+
 func TestBasicAuth(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixup for https://github.com/superfly/spegel/pull/2

Fixes error when running registry with push enabled: `GET /v2/{app_name}/blobs/uploads/{uuid} matches more methods than HEAD /v2/, but has a more specific path pattern`

https://pkg.go.dev/net/http#ServeMux:
> A pattern with the method GET matches both GET and HEAD requests